### PR TITLE
feat: Add production build stage to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM node
-
-COPY . . 
+FROM node AS node_modules
+WORKDIR /app
+COPY package-lock.json package.json ./
 RUN npm install
+COPY . .
 
+FROM node_modules AS prod_builder
+RUN npm run build
+
+FROM nginx AS prod
+COPY --from=prod_builder /app/build /usr/share/nginx/html
+
+FROM node_modules AS dev
 EXPOSE 3000
 CMD npm run start


### PR DESCRIPTION
Modifications:

Split the dockerfile into stages

1. Refactored the dockerfile and introduced an `node_modules` stage, where install is cached unless package.json or package-lock.json changes
2. Added prod_builder stage that builds the app, it only runs for prod builds
3. Added a prod stage that creates an image with nginx and the compiled app
4. Refactored the old Dockerfile to build on top of the node_modules stage

Results:

You can either build, by default, the dev image or the prod image by adding `--target=prod` to docker build